### PR TITLE
Refactor switchport template, add purge_vlans template

### DIFF
--- a/README.md
+++ b/README.md
@@ -31,10 +31,11 @@ Role Variables
 
 There are some variables that control global purging functions.
 
-|                          Variable | Type                  | Notes                                                                                                                                                                        |
-|----------------------------------:|-----------------------|------------------------------------------------------------------------------------------------------------------------------------------------------------------------------|
-|       eos_purge_vlan_trunk_groups | boolean: true, false* | When the role provisions vlan trunk groups, it will remove extraneous trunk groups that are present in the configuration but haven't specified in your host variables.       |
-| eos_purge_switchport_trunk_groups | boolean: true, false* | When the role provisions switchport trunk groups, it will remove extraneous trunk groups that are present in the configuration but haven't specified in your host variables. |
+|                          Variable | Type                  | Notes                                    |
+| --------------------------------: | --------------------- | ---------------------------------------- |
+|       eos_purge_vlan_trunk_groups | boolean: true, false* | If true, when the role provisions vlan trunk groups, it will remove extraneous trunk groups that are present in the configuration but haven't been specified in your host variables. |
+| eos_purge_switchport_trunk_groups | boolean: true, false* | If true, when the role provisions switchport trunk groups, it will remove extraneous trunk groups that are present in the configuration but haven't been specified in your host variables. |
+|                   eos_purge_vlans | boolean: true, false* | If true, when the role provisions vlans, it will remove extraneous vlans that are present in the configuration but haven't been specified in your host variables. |
 
 
 The tasks in this role are driven by the ``switchports`` and ``vlans`` objects
@@ -42,25 +43,25 @@ described below:
 
 **switchports** (list) each entry contains the following keys:
 
-|                 Key | Type                      | Notes                                                  |
-|--------------------:|---------------------------|--------------------------------------------------------|
-|                name | string (required)         | The interface name of the switchport                   |
-|                mode | choices: access*, trunk   | Mode of operation for the interface                    |
-|         access_vlan | string                    | Only required for http or https connections            |
+|                 Key | Type                      | Notes                                    |
+| ------------------: | ------------------------- | ---------------------------------------- |
+|                name | string (required)         | The interface name of the switchport     |
+|                mode | choices: access*, trunk   | Mode of operation for the interface      |
+|         access_vlan | string                    | Only required for http or https connections |
 |   trunk_native_vlan | string                    | Vlan associated with the interface. Used if mode=trunk |
-| trunk_allowed_vlans | list                      | The native vlan used when mode=trunk.                  |
-|        trunk_groups | list                      | The set of trunk groups configured on the interface    |
-|               state | choices: present*, absent | Set the state for the switchport                       |
+| trunk_allowed_vlans | list                      | The native vlan used when mode=trunk.    |
+|        trunk_groups | list                      | The set of trunk groups configured on the interface |
+|               state | choices: present*, absent | Set the state for the switchport         |
 
 **vlans** (list) each entry contains the following keys:
 
-|          Key | Type                      | Notes                                                 |
-|-------------:|---------------------------|-------------------------------------------------------|
+|          Key | Type                      | Notes                                    |
+| -----------: | ------------------------- | ---------------------------------------- |
 |       vlanid | int (required)            | The vlan id. Example: 1, 1000, 1024. Without the Vlan |
-|         name | string                    | The name for the vlan. No spaces allowed.             |
-| trunk_groups | list                      | The set of trunk groups configured on the interface   |
-|       enable | boolean: true*, false     |                                                       |
-|        state | choices: present*, absent | Set the state for the vlan                            |
+|         name | string                    | The name for the vlan. No spaces allowed. |
+| trunk_groups | list                      | The set of trunk groups configured on the interface |
+|       enable | boolean: true*, false     |                                          |
+|        state | choices: present*, absent | Set the state for the vlan               |
 
 
 ```

--- a/filter_plugins/range_filter.py
+++ b/filter_plugins/range_filter.py
@@ -1,0 +1,55 @@
+# (c) 2015, Peter Sprygada <psprygada@ansible.com>
+#
+# This file is part of Ansible
+#
+# Ansible is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# Ansible is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with Ansible.  If not, see <http://www.gnu.org/licenses/>.
+#
+
+from itertools import groupby
+
+__metaclass__ = type
+
+def make_range_string(data):
+    numlist = []
+    for item in data:
+        for part in str(item).split(','):
+            if '-' in part:
+                first, last = part.split('-')
+                first, last = int(first), int(last)
+                numlist.extend(range(first, last+1))
+            else:
+                first = int(part)
+                numlist.append(first)
+
+    numlist = sorted(set(numlist))
+
+    range_list = []
+    for _, grp in groupby(enumerate(numlist), lambda (i, x): i-x):
+        subset = [ x[1] for x in list(grp) ]
+        first = subset[0]
+        last = subset[-1]
+        if first == last:
+            range_list.append(str(first))
+        else:
+            substr = "{}-{}".format(first, last)
+            range_list.append(substr)
+
+    return ','.join(range_list)
+
+class FilterModule(object):
+
+    def filters(self):
+        return {
+            'make_range_string': make_range_string,
+        }

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -38,6 +38,26 @@
   when: vlans is defined
   with_items: '{{ vlans|default([]) }}'
 
+- name: Arista EOS purge VLAN resources
+  eos_template:
+    src=purge_vlans.j2
+    include_defaults=True
+    config={{ _eos_config|default(omit) }}
+    provider={{ provider|default(omit) }}
+    auth_pass={{ auth_pass|default(omit) }}
+    authorize={{ authorize|default(omit) }}
+    host={{ host|default(omit) }}
+    password={{ password|default(omit) }}
+    port={{ port|default(omit) }}
+    transport={{ transport|default(omit) }}
+    use_ssl={{ use_ssl|default(omit) }}
+    username={{ username|default(omit) }}
+  when:
+    eos_purge_vlans is defined and
+    eos_purge_vlans and
+    vlans is defined
+  with_items: '{{ eos_purge_vlans|default([]) }}'
+
 - name: Arista EOS switchport resources
   eos_template:
     src=switchport.j2

--- a/templates/purge_vlans.j2
+++ b/templates/purge_vlans.j2
@@ -1,0 +1,23 @@
+#jinja2: trim_blocks: False
+#jinja2: lstrip_blocks: False
+
+{% set vlan_list = [] %}
+{% for vlan in vlans %}
+   {% if vlan.vlanid is defined %}
+      {% set _ = vlan_list.append("%s" % vlan.vlanid) %}
+   {% endif %}
+{% endfor %}
+
+{% set config_list = _eos_config | re_findall('^vlan (\d+)') %}
+{% set tmp_list = [] %}
+{% for id in config_list %}
+   {% set _ = tmp_list.append(id) %}
+{% endfor %}
+
+{% set purge_list = tmp_list | difference(vlan_list) %}
+
+{% for vlan_id in purge_list %}
+
+no vlan {{ vlan_id }}
+
+{% endfor %}

--- a/templates/switchport.j2
+++ b/templates/switchport.j2
@@ -10,14 +10,41 @@ interface {{ item.name }}
  {# These default commands only run the first time absent is called #}
  {% set switchport_block = _eos_config | config_block('interface ' ~ item.name, indent=3) %}
    {% if switchport_block %}
-    {% if switchport_block | join('\n') | re_search('^switchport$') %}
+    {% set switchport_block_str = switchport_block | join('\n') %}
+
+    {% set mode = switchport_block_str | re_search('^switchport mode (\w+)$') %}
+    {% if mode %}
+      {% if mode != 'access' %}
    default switchport mode
-   default switchport trunk group
-   default switchport trunk native vlan
-   default switchport trunk allowed vlan
-   default switchport access vlan
+      {% endif %}
     {% endif %}
-   {% endif %}
+
+    {% if switchport_block_str | re_search('^switchport trunk group \w') %}
+   default switchport trunk group
+    {% endif %}
+
+    {% set native = switchport_block_str | re_search('^switchport trunk native vlan (\d+)$') %}
+    {% if native %}
+      {% if native != '1' %}
+   default switchport trunk native vlan
+      {% endif %}
+    {% endif %}
+
+    {% set allowed = switchport_block_str | re_search('^switchport trunk allowed vlan ([-,\d]+)$') %}
+    {% if allowed %}
+      {% if allowed != '1-4096' %}
+   default switchport trunk allowed vlan
+      {% endif %}
+    {% endif %}
+
+    {% set access = switchport_block_str | re_search('^switchport access vlan (\d+)$') %}
+    {% if access %}
+      {% if access != '1' %}
+   default switchport access vlan
+      {% endif %}
+    {% endif %}
+
+   {% endif %}  {# if switchport_block #}
 
 {% elif state == 'present' %}
 interface {{ item.name }}
@@ -25,9 +52,8 @@ interface {{ item.name }}
    switchport mode {{ item.mode|default('access')}}
  {% if item.mode == 'trunk' %}
   {% if 'trunk_allowed_vlans' in item %}
-   {% for vlan in item.trunk_allowed_vlans %}
-   switchport trunk allowed vlan {{ vlan }}
-   {% endfor %}
+   {% set vlan_list = item.trunk_allowed_vlans | make_range_string %}
+   switchport trunk allowed vlan {{ vlan_list }}
   {% endif %}
   {% if 'trunk_groups' in item %}
    {% for group in item.trunk_groups %}


### PR DESCRIPTION
Fixes #4 and #5
Add eos_purge_vlans functionality to remove extraneous vlans.
Change switchport absent functionality to check each component of the configuration to ensure default has been set.
Change switchport trunk allowed vlan implementation to generate a list of ranges from the list of input values.

Release Note:
Ensure default config is saved when a switchport configuration is marked as absent.
Refactor 'switchport trunk allowed vlan' handling.
Implement eos_purge_vlans key to purge vlans that are not specified in the host vars.
