### PR TITLE
Updates for handling Ansible 2.2 changes

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -7,3 +7,5 @@ default_vlan_state: present
 
 eos_purge_switchport_trunk_groups: no
 default_switchport_state: present
+
+resource_version: '2.2'

--- a/eos_module.yml
+++ b/eos_module.yml
@@ -21,6 +21,25 @@
         username: "{{ username | default(omit) }}"
       when: module == 'eos_command'
 
+    # Call the eos_config module if module is set to eos_config
+    - name: "{{ description | default('config playbook task') }}"
+      eos_config:
+        lines: "{{ lines | default(['']) }}"
+        parents: "{{ parents | default(omit) }}"
+        before: "{{ before | default(omit) }}"
+        after: "{{ after | default(omit) }}"
+        match: "{{ match | default('none')}}"
+        auth_pass: "{{ auth_pass | default(omit) }}"
+        authorize: "{{ authorize | default(omit) }}"
+        host: "{{ host | default(omit) }}"
+        password: "{{ password | default(omit) }}"
+        port: "{{ port | default(omit) }}"
+        provider: "{{ provider | default(omit) }}"
+        transport: "cli"
+        use_ssl: "{{ use_ssl | default(omit) }}"
+        username: "{{ username | default(omit) }}"
+      when: module == 'eos_config'
+
     # Call the eos_template module if module is set to eos_template
     - name: "{{ description | default('template playbook task') }}"
       eos_template:
@@ -35,4 +54,6 @@
         transport: "cli"
         use_ssl: "{{ use_ssl | default(omit) }}"
         username: "{{ username | default(omit) }}"
-      when: module == 'eos_template'
+      when: module == 'eos_template' and
+            (ansible_version.major < 2 or
+             (ansible_version.major == 2 and ansible_version.minor < 2))

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -1,4 +1,14 @@
 ---
+# Determine what resources we will use for running the role:
+# If using Ansible 2.1 or lower, we can use eos_template
+# If using Ansible 2.2 or higher, we must use eos_config
+# resource_version is set to 2.2 by default (since most users will be
+# on updated versions), change it if we're running 2.1 or lower.'
+- set_fact:
+    resource_version: '2.1'
+  when: ansible_version.major < 2 or
+        (ansible_version.major == 2 and ansible_version.minor < 2)
+
 # Force CLI for eos_command to ensure running config is returned properly
 - name: Gather EOS configuration
   eos_command:
@@ -21,59 +31,6 @@
   no_log: "{{ no_log | default(true) }}"
   when: _eos_config is not defined
 
-- name: Arista EOS VLAN resources
-  eos_template:
-    src: vlan.j2
-    include_defaults: True
-    config: "{{ _eos_config | default(omit) }}"
-    provider: "{{ provider | default(omit) }}"
-    auth_pass: "{{ auth_pass | default(omit) }}"
-    authorize: "{{ authorize | default(omit) }}"
-    host: "{{ host | default(omit) }}"
-    password: "{{ password | default(omit) }}"
-    port: "{{ port | default(omit) }}"
-    transport: "{{ transport | default(omit) }}"
-    use_ssl: "{{ use_ssl | default(omit) }}"
-    username: "{{ username | default(omit) }}"
-  notify: save running config
-  when: vlans is defined
-  with_items: "{{ vlans | default([]) }}"
-
-- name: Arista EOS purge VLAN resources
-  eos_template:
-    src: purge_vlans.j2
-    include_defaults: True
-    config: "{{ _eos_config | default(omit) }}"
-    provider: "{{ provider | default(omit) }}"
-    auth_pass: "{{ auth_pass | default(omit) }}"
-    authorize: "{{ authorize | default(omit) }}"
-    host: "{{ host | default(omit) }}"
-    password: "{{ password | default(omit) }}"
-    port: "{{ port | default(omit) }}"
-    transport: "{{ transport | default(omit) }}"
-    use_ssl: "{{ use_ssl | default(omit) }}"
-    username: "{{ username | default(omit) }}"
-  notify: save running config
-  when:
-    eos_purge_vlans is defined and
-    eos_purge_vlans and
-    vlans is defined
-  with_items: "{{ eos_purge_vlans | default([]) }}"
-
-- name: Arista EOS switchport resources
-  eos_template:
-    src: switchport.j2
-    include_defaults: True
-    config: "{{ _eos_config | default(omit) }}"
-    provider: "{{ provider | default(omit) }}"
-    auth_pass: "{{ auth_pass | default(omit) }}"
-    authorize: "{{ authorize | default(omit) }}"
-    host: "{{ host | default(omit) }}"
-    password: "{{ password | default(omit) }}"
-    port: "{{ port | default(omit) }}"
-    transport: "{{ transport | default(omit) }}"
-    use_ssl: "{{ use_ssl | default(omit) }}"
-    username: "{{ username | default(omit) }}"
-  notify: save running config
-  when: switchports is defined
-  with_items: "{{ switchports | default([]) }}"
+# Import the resource tasks based on the version of ansible in use
+- name: Include the Arista EOS Bridging resources
+  include: "tasks/resources{{ resource_version }}.yml"

--- a/tasks/resources2.1.yml
+++ b/tasks/resources2.1.yml
@@ -1,0 +1,58 @@
+# Perform the EOS interface tasks under Ansible 2.1 or earlier
+# using the Ansible eos_template module
+- name: Arista EOS VLAN resources (Ansible <= 2.1)
+  eos_template:
+    src: vlan.j2
+    include_defaults: True
+    config: "{{ _eos_config | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    transport: "{{ transport | default(omit) }}"
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when: vlans is defined
+  with_items: "{{ vlans | default([]) }}"
+
+- name: Arista EOS purge VLAN resources (Ansible <= 2.1)
+  eos_template:
+    src: purge_vlans.j2
+    include_defaults: True
+    config: "{{ _eos_config | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    transport: "{{ transport | default(omit) }}"
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when:
+    eos_purge_vlans is defined and
+    eos_purge_vlans and
+    vlans is defined
+  with_items: "{{ eos_purge_vlans | default([]) }}"
+
+- name: Arista EOS switchport resources (Ansible <= 2.1)
+  eos_template:
+    src: switchport.j2
+    include_defaults: True
+    config: "{{ _eos_config | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    transport: "{{ transport | default(omit) }}"
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when: switchports is defined
+  with_items: "{{ switchports | default([]) }}"

--- a/tasks/resources2.2.yml
+++ b/tasks/resources2.2.yml
@@ -1,0 +1,58 @@
+# Perform the EOS interface tasks under Ansible 2.2 or later
+# using the Ansible eos_config module
+- name: Arista EOS VLAN resources (Ansible >= 2.2)
+  eos_config:
+    src: vlan.j2
+    defaults: True
+    config: "{{ _eos_config | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    transport: "{{ transport | default(omit) }}"
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when: vlans is defined
+  with_items: "{{ vlans | default([]) }}"
+
+- name: Arista EOS purge VLAN resources (Ansible >= 2.2)
+  eos_config:
+    src: purge_vlans.j2
+    defaults: True
+    config: "{{ _eos_config | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    transport: "{{ transport | default(omit) }}"
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when:
+    eos_purge_vlans is defined and
+    eos_purge_vlans and
+    vlans is defined
+  with_items: "{{ eos_purge_vlans | default([]) }}"
+
+- name: Arista EOS switchport resources (Ansible >= 2.2)
+  eos_config:
+    src: switchport.j2
+    defaults: True
+    config: "{{ _eos_config | default(omit) }}"
+    provider: "{{ provider | default(omit) }}"
+    auth_pass: "{{ auth_pass | default(omit) }}"
+    authorize: "{{ authorize | default(omit) }}"
+    host: "{{ host | default(omit) }}"
+    password: "{{ password | default(omit) }}"
+    port: "{{ port | default(omit) }}"
+    transport: "{{ transport | default(omit) }}"
+    use_ssl: "{{ use_ssl | default(omit) }}"
+    username: "{{ username | default(omit) }}"
+  notify: save running config
+  when: switchports is defined
+  with_items: "{{ switchports | default([]) }}"

--- a/test/testcases/switchport.yml
+++ b/test/testcases/switchport.yml
@@ -68,7 +68,7 @@ testcases:
          switchport
          switchport mode trunk
          switchport trunk native vlan 33
-         switchport trunk allowed vlans 250-300
+         switchport trunk allowed vlan 250-300
          switchport trunk group peering5
          switchport trunk group peering6
 
@@ -101,6 +101,6 @@ testcases:
          switchport
          switchport mode trunk
          switchport trunk native vlan 33
-         switchport trunk allowed vlans 250-300
+         switchport trunk allowed vlan 250-300
          switchport trunk group peering5
          switchport trunk group peering6


### PR DESCRIPTION
Put tasks for eos_template and eos_config into separate resource
files, then import those task files into main according to the
version of Ansible being used.

Update test cases to fix errors in configuration checking
